### PR TITLE
Add Supabase schema and onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# telegram-stickers
+# Telegram AI Sticker Pack Bot Starter
+
+This repository collects the production-ready database schema, privacy policy, and setup checklist for a Telegram bot that sells AI-generated sticker packs for **300 Telegram Stars** per order. Use it as a reference while you build your own implementation.
+
+## Contents
+- [`docs/supabase-schema.sql`](docs/supabase-schema.sql) – ready-to-run SQL for Supabase (tables, enums, indexes).
+- [`docs/privacy-policy.md`](docs/privacy-policy.md) – GDPR-friendly privacy policy template tailored for Cyprus.
+- [`docs/getting-started.md`](docs/getting-started.md) – step-by-step guide covering Supabase, Telegram bots, payments, and compliance tasks.
+
+## How to use this repository
+1. Read the [Getting Started Guide](docs/getting-started.md) to understand the tools you need and the overall workflow.
+2. Paste the SQL file into the Supabase SQL editor to create your database objects.
+3. Update the privacy policy with your organisation details and publish it on your landing page or mini app.
+4. Implement the server-side logic (webhooks, payment handling, AI generation) following the checklist in the guide.
+
+You do not need to deploy anything from this repo directly. Instead, copy the snippets into your own bot project or documentation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,75 @@
+# Getting Started Guide
+
+This guide walks you through everything you need to set up the AI sticker-pack bot, even if you are new to programming.
+
+## 1. Accounts and tools you need
+1. **Telegram account** – you already have one if you use Telegram.
+2. **Telegram Bot** – talk to [@BotFather](https://t.me/BotFather) in Telegram and follow the steps to create a new bot. Save the bot token you receive.
+3. **Supabase account** – sign up at https://supabase.com and create a new project. Choose the EU (Frankfurt) region if you want to stay in the EU.
+4. **Version control basics** – install [Git](https://git-scm.com/downloads) on your computer so you can track changes to this project.
+5. **Code editor** – download [Visual Studio Code](https://code.visualstudio.com/) or another editor of your choice.
+
+## 2. Prepare the Supabase database
+1. Open your Supabase project dashboard.
+2. Click **SQL Editor** in the left navigation.
+3. Copy the contents of [`docs/supabase-schema.sql`](./supabase-schema.sql) from this repository and paste it into a new query.
+4. Press **Run**. Supabase will create all tables, types, and indexes for you.
+5. Go to **Storage** in Supabase and create three **private** buckets named `uploads`, `stickers`, and `exports`.
+6. Under each bucket, set the **file lifecycle** rules:
+   - `uploads`: delete files after 30 days.
+   - `stickers`: delete files after 90 days.
+   - `exports`: delete files after 1 day (24 hours).
+7. In the **Authentication** → **Policies** section, make sure Row Level Security (RLS) stays enabled on all tables. You will use the Supabase service-role key inside your server to bypass RLS where necessary.
+
+## 3. Connect your bot to Supabase
+1. In Supabase, open **Project Settings** → **API** and copy the **Project URL** and **service_role key**.
+2. On your computer, create an `.env` file for your bot server (for example `BOT_TOKEN=...`, `SUPABASE_URL=...`, `SUPABASE_SERVICE_KEY=...`). Never share this file publicly.
+3. If you do not have a server yet, plan to use [Supabase Edge Functions](https://supabase.com/docs/guides/functions) or a small Node.js/Python server hosted on platforms like Railway, Render, or Fly.io.
+
+## 4. Handle Telegram webhooks
+1. Your server needs an HTTPS URL that Telegram can reach. Services like Railway or Vercel can host it.
+2. Use the Telegram Bot API method [`setWebhook`](https://core.telegram.org/bots/api#setwebhook) to point Telegram to your server endpoint (for example `https://yourdomain.com/tg-webhook`).
+3. Implement an endpoint that receives JSON updates. Store incoming events in the `public.webhook_events` table for audit/debugging.
+4. When a user sends `/start`, collect their Telegram profile data and upsert it into `public.telegram_profiles`.
+5. When a user sends a photo, upload it to the Supabase `uploads` bucket, create a record in `public.uploads`, and ask them to choose a style.
+
+## 5. Payments with Telegram Stars
+1. Read [Telegram’s Stars documentation](https://core.telegram.org/bots/api#telegram-star-payments) so you know the rules.
+2. When the user picks a style, create a row in `public.orders` with `status='pending'` and `price_stars=300`.
+3. Call the Bot API method `createInvoiceLink` to generate a Stars payment link and store the response in `invoice_link`.
+4. Send the link to the user so they can pay inside Telegram.
+5. Handle the payment confirmation in your webhook (look for the `successful_payment` update). Insert a row into `public.payments` and update the related order to `status='paid'`.
+
+## 6. Generating stickers
+1. After payment, enqueue a job by inserting into `public.generations` with `status='queued'`.
+2. Run a worker (Edge Function, serverless job, or background worker) that reads queued generations, calls your AI image model, and stores the resulting files in the `stickers` bucket.
+3. Ensure each generated sticker complies with Telegram’s technical rules:
+   - Static: PNG or WEBP, one side exactly 512 px, transparent background recommended.
+   - Animated: `.tgs` (Lottie) format.
+   - Video: `.webm` VP9 codec, max 3 seconds, max 30 FPS, one side exactly 512 px, max 256 KB, no audio.
+4. Record each sticker in `public.stickers` with file metadata.
+
+## 7. Building the Telegram sticker set
+1. Use the Bot API method `createNewStickerSet` (or `createNewVideoStickerSet` / `createNewAnimatedStickerSet`) to create a set named like `username_style_byYourBot`.
+2. Insert a row into `public.sticker_sets` with the Telegram user, set name, and status `creating`.
+3. Use `addStickerToSet` for each generated sticker. Map each sticker to an emoji and create rows in `public.sticker_set_items`.
+4. When Telegram confirms the set is ready, update the row to `status='ready'` and send the `t.me/addstickers/<set_name>` link to the user.
+
+## 8. /erase deletion flow
+1. When a user sends `/erase`, delete their files from the `uploads`, `stickers`, and `exports` buckets.
+2. Update any related database records (`uploads.status='deleted'`, timestamps, etc.).
+3. Log the event in `public.webhook_events` so you have proof of compliance.
+
+## 9. Optional exports
+1. If you want to give users a ZIP or preview sheet, generate it on demand and upload to the `exports` bucket.
+2. Use Supabase signed URLs with a short expiry to share the file.
+
+## 10. Keep documentation up to date
+- Update the [Privacy Policy](privacy-policy.md) with your company details and publish it on your website or bot landing page.
+- Record a lightweight Data Protection Impact Assessment (DPIA) and store it securely.
+- Add a consent prompt before running generation jobs.
+
+## Need more help?
+- Supabase docs: https://supabase.com/docs
+- Telegram Bot API: https://core.telegram.org/bots/api
+- If you get stuck, search for tutorials on “Telegram bot webhook Node.js” or similar in your preferred language.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,56 @@
+# Privacy Policy for [Your Bot Name] on Telegram
+
+**Controller.** [Your Company Name], [registered address], Cyprus. Contact: [email], [phone].
+
+## What this policy covers
+This policy explains how we process your personal data when you use our Telegram bot to generate and publish sticker packs.
+
+## Categories of data we process
+- **Telegram account data** provided by Telegram to the bot, such as your Telegram user ID, username, display name, and language.
+- **Images you upload** to the bot to create stickers. These may include your face and could become biometric data if used for identification.
+- **Purchase and payment metadata** related to Telegram Stars payments, such as invoice identifiers and confirmation events. We do not receive your card or app-store billing details.
+- **Technical logs** such as timestamps and error diagnostics.
+
+## Purposes and legal bases
+- **Provide the service.** Receive your image, generate stickers, create a sticker pack and deliver it to you. *Legal basis:* performance of a contract you enter by using the bot, and your consent for processing of photos that may contain biometric data.
+- **Payments and fraud prevention.** *Legal basis:* performance of a contract and legitimate interests.
+- **Security, debugging, analytics limited to service quality.** *Legal basis:* legitimate interests.
+- **Compliance with legal obligations.**
+
+## Explicit consent for photos
+Because selfies can constitute biometric data if processed for unique identification, we request your explicit consent before generation. You may withdraw consent at any time by sending `/erase` to the bot. If you withdraw consent, we will stop processing your images and delete them, except for data we must retain for legal or payment records.
+
+## Where we store data
+We use Supabase (EU-hosted option where possible) for storage and databases and reputable AI model providers. Some processing may occur outside the EEA. Where we transfer data internationally, we rely on appropriate safeguards such as Standard Contractual Clauses.
+
+## Retention
+- **Source images in uploads:** 30 days, then deleted automatically.
+- **Generated stickers in stickers:** 90 days for re-download and support, then deleted.
+- **Webhook logs and payment records:** up to 6 years as required for accounting and legal obligations.
+- You can request earlier deletion at any time.
+
+## Sharing
+- Telegram as platform provider and payment facilitator via Stars.
+- Cloud infrastructure and AI vendors acting as processors under GDPR-compliant terms.
+- Authorities when required by law.
+
+## Your rights
+You can request access, correction, deletion, restriction or portability of your data, and object to processing. You can withdraw consent at any time by sending `/erase` in the bot or contacting us. You also have the right to lodge a complaint with the Office of the Commissioner for Personal Data Protection in Cyprus. Contact and guidance are available on the Commissioner's website: https://www.dataprotection.gov.cy.
+
+## Children
+The service is for users aged 16 and over in the EEA. Do not upload photos of children.
+
+## Security
+We use encryption in transit, access controls, and short-lived signed URLs. If we suffer a personal-data breach likely to result in risk to you, we will notify the Cyprus supervisory authority and affected users in accordance with GDPR.
+
+## Payments via Telegram Stars
+Purchases are processed in Telegram. We receive payment confirmations and amounts in Stars only. Please see Telegram's terms and your app store terms for how Stars are purchased or refunded.
+
+## Contact
+[Company name], [address], [email]. If you have a data-protection concern, contact us first. You may also contact the Cyprus Commissioner at https://www.dataprotection.gov.cy.
+
+## Effective date
+[Insert date]
+
+## Changes
+We will update this policy as needed and post the latest version in-bot and on our website.

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,149 @@
+-- Supabase schema for the Telegram AI sticker pack bot
+-- Run this script inside the Supabase SQL editor (public schema)
+
+-- 1) Users coming from Telegram
+create table public.telegram_profiles (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint unique not null,
+  tg_username text,
+  first_name text,
+  language_code text,
+  is_premium boolean default false,
+  country_code text,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz
+);
+
+-- 2) Styles/themes your bot offers
+create table public.styles (
+  id uuid primary key default gen_random_uuid(),
+  key text unique not null,
+  title text not null,
+  description text,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+-- 3) Photo uploads (source images)
+create table public.uploads (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  storage_path text not null,
+  mime_type text not null,
+  width int,
+  height int,
+  sha256 bytea,
+  status text not null default 'ready',
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+create index on public.uploads (tg_user_id, created_at desc);
+
+-- 4) Orders (one per sticker pack purchase attempt)
+create type order_status as enum ('pending','paid','failed','refunded','expired');
+create table public.orders (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  style_id uuid not null references public.styles(id),
+  price_stars int not null default 300,
+  invoice_link text,
+  invoice_payload jsonb,
+  status order_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  paid_at timestamptz
+);
+create index on public.orders (tg_user_id, created_at desc);
+
+-- 5) Payments via Telegram Stars
+create type payment_status as enum ('pending','succeeded','failed','refunded');
+create table public.payments (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  tg_charge_id text,
+  amount_stars int not null,
+  status payment_status not null,
+  provider_data jsonb,
+  created_at timestamptz not null default now()
+);
+create index on public.payments (order_id);
+
+-- 6) Generations (the AI job)
+create type gen_status as enum ('queued','processing','succeeded','failed');
+create table public.generations (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  input_upload_id uuid not null references public.uploads(id) on delete restrict,
+  engine text not null,
+  prompt text not null,
+  params jsonb,
+  status gen_status not null default 'queued',
+  error text,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index on public.generations (order_id);
+
+-- 7) Individual sticker images
+create type sticker_format as enum ('png','webp','webm','tgs');
+create table public.stickers (
+  id uuid primary key default gen_random_uuid(),
+  generation_id uuid not null references public.generations(id) on delete cascade,
+  emotion text,
+  storage_path text not null,
+  file_size_bytes int,
+  width int,
+  height int,
+  format sticker_format not null default 'png',
+  sha256 bytea,
+  created_at timestamptz not null default now()
+);
+create index on public.stickers (generation_id);
+
+-- 8) Sticker set created in Telegram
+create type set_status as enum ('creating','ready','failed');
+create table public.sticker_sets (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  set_name text unique,
+  title text not null,
+  type text not null default 'static',
+  link text,
+  status set_status not null default 'creating',
+  created_at timestamptz not null default now(),
+  ready_at timestamptz
+);
+
+-- 9) Mapping between your stickers and the TG sticker set
+create table public.sticker_set_items (
+  id uuid primary key default gen_random_uuid(),
+  sticker_set_id uuid not null references public.sticker_sets(id) on delete cascade,
+  sticker_id uuid not null references public.stickers(id) on delete cascade,
+  emoji text default '🙂'
+);
+
+-- 10) Webhook audit (Telegram updates, payment events)
+create table public.webhook_events (
+  id bigint generated always as identity primary key,
+  source text not null,
+  event_type text not null,
+  payload jsonb not null,
+  received_at timestamptz not null default now(),
+  order_id uuid,
+  tg_user_id bigint
+);
+create index on public.webhook_events (received_at desc);
+
+-- 11) Minimal usage ledger (optional throttle/anti-abuse)
+create table public.usage_ledger (
+  id bigint generated always as identity primary key,
+  tg_user_id bigint not null,
+  kind text not null,
+  units int not null default 1,
+  created_at timestamptz not null default now()
+);
+create index on public.usage_ledger (tg_user_id, created_at desc);
+
+-- Storage and RLS notes
+-- Create private buckets: uploads, stickers, exports
+-- Remember to enable RLS on all tables and add service-role or user policies as needed


### PR DESCRIPTION
## Summary
- add Supabase schema SQL file covering Telegram bot data model and storage notes
- include GDPR-ready privacy policy template tailored for Cyprus-based operator
- document beginner-friendly setup steps for Supabase, Telegram, payments, and compliance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc3e264d38832d95347a2e8eb859f9