### PR TITLE
Add Express webhook server and expand onboarding docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Telegram bot token issued by @BotFather
+TELEGRAM_BOT_TOKEN=123456789:replace-with-real-token
+
+# Optional: secret token you set when registering the webhook
+TELEGRAM_WEBHOOK_SECRET=super-secret-token
+
+# Supabase project credentials (service role key is required for RLS bypass)
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=service-role-key
+
+# Server configuration
+PORT=8787
+PRICE_STARS=300
+GENERATION_ENGINE=manual-review

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.env
+.DS_Store
+npm-debug.log*
+
+# Supabase local config
+supabase/.branches
+supabase/.temp

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# telegram-stickers
+# Telegram AI Sticker Pack Bot Starter
+
+This repository collects a production-ready database schema, privacy policy, setup checklist, and a starter Express server for a Telegram bot that sells AI-generated sticker packs for **300 Telegram Stars** per order. Use it as a reference while you build your own implementation.
+
+## Contents
+- [`docs/supabase-schema.sql`](docs/supabase-schema.sql) – ready-to-run SQL for Supabase (tables, enums, indexes).
+- [`docs/privacy-policy.md`](docs/privacy-policy.md) – GDPR-friendly privacy policy template tailored for Cyprus.
+- [`docs/getting-started.md`](docs/getting-started.md) – step-by-step guide covering Supabase, Telegram bots, payments, and compliance tasks.
+- [`src/index.js`](src/index.js) – Express webhook server that wires Telegram updates into the Supabase schema.
+- [`src/lib`](src/lib) – helper clients for Supabase and the Telegram Bot API.
+- [`.env.example`](.env.example) – environment variables you must configure before running the server.
+
+## Quick start
+
+1. **Install prerequisites**: Node.js 18+, npm, and Git on your computer.
+2. **Clone the repo** and install dependencies:
+   ```bash
+   git clone <your-fork-url>
+   cd telegram-stickers
+   npm install
+   ```
+3. **Create an environment file** based on [`.env.example`](.env.example):
+   ```bash
+   cp .env.example .env
+   ```
+   Fill in your Telegram bot token, Supabase project URL, and service-role key.
+4. **Run the Supabase SQL** from [`docs/supabase-schema.sql`](docs/supabase-schema.sql) and insert at least one row into `public.styles` so the bot can offer a pack style.
+5. **Start the webhook server locally**:
+   ```bash
+   npm start
+   ```
+6. **Expose your server** (for example with [ngrok](https://ngrok.com/)) and point your bot webhook to it:
+   ```bash
+   curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+     -d url="https://<your-ngrok-subdomain>.ngrok.app/tg-webhook" \
+     -d secret_token="$(grep TELEGRAM_WEBHOOK_SECRET .env | cut -d'=' -f2)"
+   ```
+7. **Send `/start` and a photo to your bot**. The server will store the file in Supabase, create orders, and generate Telegram Stars invoices.
+
+The starter server logs the user into `telegram_profiles`, saves uploads, creates orders, records payments, queues generations, and implements the `/erase` deletion flow. You still need to build a background worker that reads rows from `public.generations` and writes finished stickers into the `stickers` bucket.
+
+## How to use this repository
+1. Read the [Getting Started Guide](docs/getting-started.md) to understand the tools you need and the overall workflow.
+2. Paste the SQL file into the Supabase SQL editor to create your database objects.
+3. Update the privacy policy with your organisation details and publish it on your landing page or mini app.
+4. Fill in the environment variables and run the provided Express server as a starting point for your own infrastructure.
+5. Implement the background generation worker and sticker-pack publishing logic following the checklist in the guide.
+
+You do not need to deploy anything from this repo directly. Instead, copy the snippets into your own bot project or documentation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,96 @@
+# Getting Started Guide
+
+This guide walks you through everything you need to set up the AI sticker-pack bot, even if you are new to programming.
+
+## 1. Accounts and tools you need
+1. **Telegram account** – you already have one if you use Telegram.
+2. **Telegram Bot** – talk to [@BotFather](https://t.me/BotFather) in Telegram and follow the steps to create a new bot. Save the bot token you receive.
+3. **Supabase account** – sign up at https://supabase.com and create a new project. Choose the EU (Frankfurt) region if you want to stay in the EU.
+4. **Node.js 18 or newer** – download from [nodejs.org](https://nodejs.org/en). This installs both Node and npm, which you need to run the Express server.
+5. **Version control basics** – install [Git](https://git-scm.com/downloads) on your computer so you can track changes to this project.
+6. **Code editor** – download [Visual Studio Code](https://code.visualstudio.com/) or another editor of your choice.
+7. **Tunnel tool (optional but helpful)** – tools like [ngrok](https://ngrok.com/) expose your local server to Telegram while you test.
+
+## 2. Prepare the Supabase database
+1. Open your Supabase project dashboard.
+2. Click **SQL Editor** in the left navigation.
+3. Copy the contents of [`docs/supabase-schema.sql`](./supabase-schema.sql) from this repository and paste it into a new query.
+4. Press **Run**. Supabase will create all tables, types, and indexes for you.
+5. Go to **Storage** in Supabase and create three **private** buckets named `uploads`, `stickers`, and `exports`.
+6. Under each bucket, set the **file lifecycle** rules:
+   - `uploads`: delete files after 30 days.
+   - `stickers`: delete files after 90 days.
+   - `exports`: delete files after 1 day (24 hours).
+7. In the **Authentication** → **Policies** section, make sure Row Level Security (RLS) stays enabled on all tables. You will use the Supabase service-role key inside your server to bypass RLS where necessary.
+
+## 3. Connect your bot to Supabase
+1. In Supabase, open **Project Settings** → **API** and copy the **Project URL** and **service_role key**.
+2. Copy `.env.example` to `.env` and fill in `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY`. Never share this file publicly.
+3. If you do not have a server yet, this repository includes an Express-based webhook handler in [`src/index.js`](../src/index.js) that you can run locally or deploy to a platform like Railway, Render, Fly.io, or Supabase Edge Functions.
+
+## 4. Install dependencies and run the server locally
+1. Clone your fork of this repository: `git clone <your-repo-url>`.
+2. Change into the directory and install dependencies: `cd telegram-stickers && npm install`.
+3. Start the Express server: `npm start`. You should see `Telegram bot server listening on port 8787` in your terminal.
+4. Keep this terminal open so the process keeps running.
+
+## 5. Expose your local server to Telegram
+1. Start `ngrok` (or a similar tunnel) pointing at your local port: `ngrok http 8787`.
+2. Copy the HTTPS URL ngrok gives you (for example `https://pretty-moth.ngrok.app`).
+3. Register the webhook with Telegram:
+   ```bash
+   curl "https://api.telegram.org/bot<YOUR_BOT_TOKEN>/setWebhook" \
+     -d url="https://pretty-moth.ngrok.app/tg-webhook" \
+     -d secret_token="$(grep TELEGRAM_WEBHOOK_SECRET .env | cut -d'=' -f2)"
+   ```
+4. Telegram should return `{"ok":true}`. If it does not, double-check the token, URL, and secret.
+
+## 6. Handle Telegram webhooks
+1. Your server needs an HTTPS URL that Telegram can reach. Services like Railway or Vercel can host it.
+2. Use the Telegram Bot API method [`setWebhook`](https://core.telegram.org/bots/api#setwebhook) to point Telegram to your server endpoint (for example `https://yourdomain.com/tg-webhook`).
+3. Implement an endpoint that receives JSON updates. Store incoming events in the `public.webhook_events` table for audit/debugging.
+4. When a user sends `/start`, collect their Telegram profile data and upsert it into `public.telegram_profiles`.
+5. When a user sends a photo, upload it to the Supabase `uploads` bucket, create a record in `public.uploads`, and ask them to choose a style.
+
+The provided Express server already implements these basics. Read through [`src/index.js`](../src/index.js) so you understand each step.
+
+## 7. Payments with Telegram Stars
+1. Read [Telegram’s Stars documentation](https://core.telegram.org/bots/api#telegram-star-payments) so you know the rules.
+2. When the user picks a style, create a row in `public.orders` with `status='pending'` and `price_stars=300`.
+3. Call the Bot API method `createInvoiceLink` to generate a Stars payment link and store the response in `invoice_link`.
+4. Send the link to the user so they can pay inside Telegram.
+5. Handle the payment confirmation in your webhook (look for the `successful_payment` update). Insert a row into `public.payments` and update the related order to `status='paid'`.
+
+## 8. Generating stickers
+1. After payment, enqueue a job by inserting into `public.generations` with `status='queued'`.
+2. Run a worker (Edge Function, serverless job, or background worker) that reads queued generations, calls your AI image model, and stores the resulting files in the `stickers` bucket.
+3. Ensure each generated sticker complies with Telegram’s technical rules:
+   - Static: PNG or WEBP, one side exactly 512 px, transparent background recommended.
+   - Animated: `.tgs` (Lottie) format.
+   - Video: `.webm` VP9 codec, max 3 seconds, max 30 FPS, one side exactly 512 px, max 256 KB, no audio.
+4. Record each sticker in `public.stickers` with file metadata.
+
+## 9. Building the Telegram sticker set
+1. Use the Bot API method `createNewStickerSet` (or `createNewVideoStickerSet` / `createNewAnimatedStickerSet`) to create a set named like `username_style_byYourBot`.
+2. Insert a row into `public.sticker_sets` with the Telegram user, set name, and status `creating`.
+3. Use `addStickerToSet` for each generated sticker. Map each sticker to an emoji and create rows in `public.sticker_set_items`.
+4. When Telegram confirms the set is ready, update the row to `status='ready'` and send the `t.me/addstickers/<set_name>` link to the user.
+
+## 10. /erase deletion flow
+1. When a user sends `/erase`, delete their files from the `uploads`, `stickers`, and `exports` buckets.
+2. Update any related database records (`uploads.status='deleted'`, timestamps, etc.).
+3. Log the event in `public.webhook_events` so you have proof of compliance.
+
+## 11. Optional exports
+1. If you want to give users a ZIP or preview sheet, generate it on demand and upload to the `exports` bucket.
+2. Use Supabase signed URLs with a short expiry to share the file.
+
+## 12. Keep documentation up to date
+- Update the [Privacy Policy](privacy-policy.md) with your company details and publish it on your website or bot landing page.
+- Record a lightweight Data Protection Impact Assessment (DPIA) and store it securely.
+- Add a consent prompt before running generation jobs.
+
+## Need more help?
+- Supabase docs: https://supabase.com/docs
+- Telegram Bot API: https://core.telegram.org/bots/api
+- If you get stuck, search for tutorials on “Telegram bot webhook Node.js” or similar in your preferred language.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,56 @@
+# Privacy Policy for [Your Bot Name] on Telegram
+
+**Controller.** [Your Company Name], [registered address], Cyprus. Contact: [email], [phone].
+
+## What this policy covers
+This policy explains how we process your personal data when you use our Telegram bot to generate and publish sticker packs.
+
+## Categories of data we process
+- **Telegram account data** provided by Telegram to the bot, such as your Telegram user ID, username, display name, and language.
+- **Images you upload** to the bot to create stickers. These may include your face and could become biometric data if used for identification.
+- **Purchase and payment metadata** related to Telegram Stars payments, such as invoice identifiers and confirmation events. We do not receive your card or app-store billing details.
+- **Technical logs** such as timestamps and error diagnostics.
+
+## Purposes and legal bases
+- **Provide the service.** Receive your image, generate stickers, create a sticker pack and deliver it to you. *Legal basis:* performance of a contract you enter by using the bot, and your consent for processing of photos that may contain biometric data.
+- **Payments and fraud prevention.** *Legal basis:* performance of a contract and legitimate interests.
+- **Security, debugging, analytics limited to service quality.** *Legal basis:* legitimate interests.
+- **Compliance with legal obligations.**
+
+## Explicit consent for photos
+Because selfies can constitute biometric data if processed for unique identification, we request your explicit consent before generation. You may withdraw consent at any time by sending `/erase` to the bot. If you withdraw consent, we will stop processing your images and delete them, except for data we must retain for legal or payment records.
+
+## Where we store data
+We use Supabase (EU-hosted option where possible) for storage and databases and reputable AI model providers. Some processing may occur outside the EEA. Where we transfer data internationally, we rely on appropriate safeguards such as Standard Contractual Clauses.
+
+## Retention
+- **Source images in uploads:** 30 days, then deleted automatically.
+- **Generated stickers in stickers:** 90 days for re-download and support, then deleted.
+- **Webhook logs and payment records:** up to 6 years as required for accounting and legal obligations.
+- You can request earlier deletion at any time.
+
+## Sharing
+- Telegram as platform provider and payment facilitator via Stars.
+- Cloud infrastructure and AI vendors acting as processors under GDPR-compliant terms.
+- Authorities when required by law.
+
+## Your rights
+You can request access, correction, deletion, restriction or portability of your data, and object to processing. You can withdraw consent at any time by sending `/erase` in the bot or contacting us. You also have the right to lodge a complaint with the Office of the Commissioner for Personal Data Protection in Cyprus. Contact and guidance are available on the Commissioner's website: https://www.dataprotection.gov.cy.
+
+## Children
+The service is for users aged 16 and over in the EEA. Do not upload photos of children.
+
+## Security
+We use encryption in transit, access controls, and short-lived signed URLs. If we suffer a personal-data breach likely to result in risk to you, we will notify the Cyprus supervisory authority and affected users in accordance with GDPR.
+
+## Payments via Telegram Stars
+Purchases are processed in Telegram. We receive payment confirmations and amounts in Stars only. Please see Telegram's terms and your app store terms for how Stars are purchased or refunded.
+
+## Contact
+[Company name], [address], [email]. If you have a data-protection concern, contact us first. You may also contact the Cyprus Commissioner at https://www.dataprotection.gov.cy.
+
+## Effective date
+[Insert date]
+
+## Changes
+We will update this policy as needed and post the latest version in-bot and on our website.

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -1,0 +1,150 @@
+-- Supabase schema for the Telegram AI sticker pack bot
+-- Run this script inside the Supabase SQL editor (public schema)
+
+-- 1) Users coming from Telegram
+create table public.telegram_profiles (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint unique not null,
+  tg_username text,
+  first_name text,
+  language_code text,
+  is_premium boolean default false,
+  country_code text,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz
+);
+
+-- 2) Styles/themes your bot offers
+create table public.styles (
+  id uuid primary key default gen_random_uuid(),
+  key text unique not null,
+  title text not null,
+  description text,
+  is_active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+-- 3) Photo uploads (source images)
+create table public.uploads (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  storage_path text not null,
+  mime_type text not null,
+  width int,
+  height int,
+  sha256 bytea,
+  status text not null default 'ready',
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+create index on public.uploads (tg_user_id, created_at desc);
+
+-- 4) Orders (one per sticker pack purchase attempt)
+create type order_status as enum ('pending','paid','failed','refunded','expired');
+create table public.orders (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  style_id uuid not null references public.styles(id),
+  price_stars int not null default 300,
+  invoice_link text,
+  invoice_payload jsonb,
+  status order_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  paid_at timestamptz
+);
+create index on public.orders (tg_user_id, created_at desc);
+
+-- 5) Payments via Telegram Stars
+create type payment_status as enum ('pending','succeeded','failed','refunded');
+create table public.payments (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  tg_charge_id text,
+  amount_stars int not null,
+  status payment_status not null,
+  provider_data jsonb,
+  created_at timestamptz not null default now()
+);
+create index on public.payments (order_id);
+create unique index on public.payments (tg_charge_id) where tg_charge_id is not null;
+
+-- 6) Generations (the AI job)
+create type gen_status as enum ('queued','processing','succeeded','failed');
+create table public.generations (
+  id uuid primary key default gen_random_uuid(),
+  order_id uuid not null references public.orders(id) on delete cascade,
+  input_upload_id uuid not null references public.uploads(id) on delete restrict,
+  engine text not null,
+  prompt text not null,
+  params jsonb,
+  status gen_status not null default 'queued',
+  error text,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index on public.generations (order_id);
+
+-- 7) Individual sticker images
+create type sticker_format as enum ('png','webp','webm','tgs');
+create table public.stickers (
+  id uuid primary key default gen_random_uuid(),
+  generation_id uuid not null references public.generations(id) on delete cascade,
+  emotion text,
+  storage_path text not null,
+  file_size_bytes int,
+  width int,
+  height int,
+  format sticker_format not null default 'png',
+  sha256 bytea,
+  created_at timestamptz not null default now()
+);
+create index on public.stickers (generation_id);
+
+-- 8) Sticker set created in Telegram
+create type set_status as enum ('creating','ready','failed');
+create table public.sticker_sets (
+  id uuid primary key default gen_random_uuid(),
+  tg_user_id bigint not null references public.telegram_profiles(tg_user_id) on delete cascade,
+  set_name text unique,
+  title text not null,
+  type text not null default 'static',
+  link text,
+  status set_status not null default 'creating',
+  created_at timestamptz not null default now(),
+  ready_at timestamptz
+);
+
+-- 9) Mapping between your stickers and the TG sticker set
+create table public.sticker_set_items (
+  id uuid primary key default gen_random_uuid(),
+  sticker_set_id uuid not null references public.sticker_sets(id) on delete cascade,
+  sticker_id uuid not null references public.stickers(id) on delete cascade,
+  emoji text default '🙂'
+);
+
+-- 10) Webhook audit (Telegram updates, payment events)
+create table public.webhook_events (
+  id bigint generated always as identity primary key,
+  source text not null,
+  event_type text not null,
+  payload jsonb not null,
+  received_at timestamptz not null default now(),
+  order_id uuid,
+  tg_user_id bigint
+);
+create index on public.webhook_events (received_at desc);
+
+-- 11) Minimal usage ledger (optional throttle/anti-abuse)
+create table public.usage_ledger (
+  id bigint generated always as identity primary key,
+  tg_user_id bigint not null,
+  kind text not null,
+  units int not null default 1,
+  created_at timestamptz not null default now()
+);
+create index on public.usage_ledger (tg_user_id, created_at desc);
+
+-- Storage and RLS notes
+-- Create private buckets: uploads, stickers, exports
+-- Remember to enable RLS on all tables and add service-role or user policies as needed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1135 @@
+{
+  "name": "telegram-stickers",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "telegram-stickers",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
+        "axios": "^1.12.2",
+        "dotenv": "^17.2.2",
+        "express": "^5.1.0"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
+      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "telegram-stickers",
+  "version": "1.0.0",
+  "description": "Starter server for a Telegram AI sticker pack bot with Supabase integration.",
+  "main": "src/index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "keywords": [
+    "telegram",
+    "supabase",
+    "stickers",
+    "bot"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@supabase/supabase-js": "^2.57.4",
+    "axios": "^1.12.2",
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0"
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,27 @@
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+const config = {
+  port: parseInt(process.env.PORT ?? '8787', 10),
+  priceStars: parseInt(process.env.PRICE_STARS ?? '300', 10),
+  generationEngine: process.env.GENERATION_ENGINE ?? 'manual-review',
+  telegramBotToken: requireEnv('TELEGRAM_BOT_TOKEN'),
+  telegramWebhookSecret: process.env.TELEGRAM_WEBHOOK_SECRET || null,
+  supabaseUrl: requireEnv('SUPABASE_URL'),
+  supabaseServiceRoleKey: requireEnv('SUPABASE_SERVICE_ROLE_KEY'),
+};
+
+if (Number.isNaN(config.priceStars) || config.priceStars <= 0) {
+  throw new Error('PRICE_STARS must be a positive integer.');
+}
+
+module.exports = config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,581 @@
+const express = require('express');
+const crypto = require('crypto');
+const config = require('./config');
+const supabase = require('./lib/supabase');
+const telegram = require('./lib/telegram');
+
+const app = express();
+app.use(express.json({ limit: '5mb' }));
+
+app.get('/healthz', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.post('/tg-webhook', async (req, res) => {
+  if (config.telegramWebhookSecret) {
+    const headerSecret = req.headers['x-telegram-bot-api-secret-token'];
+    if (headerSecret !== config.telegramWebhookSecret) {
+      return res.status(403).json({ ok: false, error: 'Invalid webhook secret' });
+    }
+  }
+
+  const update = req.body;
+  try {
+    await handleUpdate(update);
+  } catch (error) {
+    console.error('Failed to process Telegram update:', error);
+  }
+  res.json({ ok: true });
+});
+
+app.use((err, req, res, _next) => {
+  console.error('Unhandled error', err);
+  res.status(500).json({ ok: false, error: 'Internal server error' });
+});
+
+app.listen(config.port, () => {
+  console.log(`Telegram bot server listening on port ${config.port}`);
+});
+
+async function handleUpdate(update) {
+  const eventType = resolveEventType(update);
+  await recordWebhookEvent(update, eventType);
+
+  if (update.pre_checkout_query) {
+    await telegram.answerPreCheckoutQuery(update.pre_checkout_query.id, true);
+    return;
+  }
+
+  if (update.callback_query) {
+    await handleCallbackQuery(update.callback_query);
+    return;
+  }
+
+  if (update.message) {
+    await handleMessage(update.message);
+  }
+}
+
+function resolveEventType(update) {
+  if (update.message?.successful_payment) return 'successful_payment';
+  if (update.message?.photo) return 'message_photo';
+  if (update.message?.text) return 'message_text';
+  if (update.callback_query) return 'callback_query';
+  if (update.pre_checkout_query) return 'pre_checkout_query';
+  return 'unknown';
+}
+
+async function recordWebhookEvent(update, eventType) {
+  const tgUserId = update.message?.from?.id
+    ?? update.callback_query?.from?.id
+    ?? update.pre_checkout_query?.from?.id
+    ?? null;
+
+  let orderId = null;
+  const invoicePayloadRaw = update.message?.successful_payment?.invoice_payload;
+  if (invoicePayloadRaw) {
+    try {
+      const parsed = JSON.parse(invoicePayloadRaw);
+      if (parsed?.order_id) {
+        orderId = parsed.order_id;
+      }
+    } catch (error) {
+      orderId = invoicePayloadRaw;
+    }
+  }
+
+  const { error } = await supabase.from('webhook_events').insert({
+    source: 'telegram',
+    event_type: eventType,
+    payload: update,
+    tg_user_id: tgUserId,
+    order_id: orderId,
+  });
+
+  if (error) {
+    console.error('Failed to record webhook event:', error);
+  }
+}
+
+async function handleMessage(message) {
+  const chatId = message.chat.id;
+  const from = message.from;
+
+  await upsertTelegramProfile(from);
+
+  if (message.successful_payment) {
+    await handleSuccessfulPayment(message);
+    return;
+  }
+
+  if (message.text) {
+    await handleTextMessage(message.text.trim(), from, chatId);
+    return;
+  }
+
+  if (message.photo?.length) {
+    await handlePhotoMessage(message, from, chatId);
+    return;
+  }
+
+  await telegram.sendMessage(chatId, 'Unsupported message type. Please send a photo.');
+}
+
+async function handleTextMessage(text, from, chatId) {
+  if (text === '/start') {
+    await telegram.sendMessage(chatId, 'Welcome! Send me a clear photo and I will guide you through purchasing your AI sticker pack.');
+    return;
+  }
+
+  if (text === '/erase') {
+    await handleEraseCommand(from.id, chatId);
+    return;
+  }
+
+  await telegram.sendMessage(chatId, 'I do not recognise that command. Send a photo to begin.');
+}
+
+async function handlePhotoMessage(message, from, chatId) {
+  const photos = message.photo || [];
+  const largestPhoto = [...photos].sort((a, b) => (a.file_size ?? 0) - (b.file_size ?? 0)).pop();
+  if (!largestPhoto) {
+    await telegram.sendMessage(chatId, 'Could not read that photo. Please try again.');
+    return;
+  }
+
+  try {
+    const file = await telegram.getFile(largestPhoto.file_id);
+    const buffer = await telegram.downloadFile(file.file_path);
+    const extension = extractExtension(file.file_path) ?? 'jpg';
+    const objectPath = `${from.id}/${crypto.randomUUID()}.${extension}`;
+    const storagePath = `uploads/${objectPath}`;
+
+    const uploadResponse = await supabase.storage.from('uploads').upload(storagePath, buffer, {
+      contentType: inferMimeType(extension),
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+    if (uploadResponse.error) {
+      throw uploadResponse.error;
+    }
+
+    const sha256Hex = crypto.createHash('sha256').update(buffer).digest('hex');
+
+    const { error } = await supabase.from('uploads').insert({
+      tg_user_id: from.id,
+      storage_path: `storage://uploads/${storagePath}`,
+      mime_type: inferMimeType(extension),
+      width: largestPhoto.width,
+      height: largestPhoto.height,
+      sha256: `\\x${sha256Hex}`,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    await telegram.sendMessage(chatId, 'Photo saved! Choose a style for your sticker pack.');
+    await sendStylePicker(chatId);
+  } catch (error) {
+    console.error('Failed to process photo upload:', error);
+    await telegram.sendMessage(chatId, 'Sorry, something went wrong while saving your photo. Please try again.');
+  }
+}
+
+function extractExtension(filePath) {
+  const parts = filePath.split('.');
+  if (parts.length <= 1) return null;
+  return parts.pop().toLowerCase();
+}
+
+function inferMimeType(extension) {
+  switch (extension) {
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    case 'gif':
+      return 'image/gif';
+    default:
+      return 'image/jpeg';
+  }
+}
+
+async function sendStylePicker(chatId) {
+  const styles = await fetchActiveStyles();
+  if (styles.length === 0) {
+    await telegram.sendMessage(chatId, 'No styles are configured yet. Add rows to the styles table in Supabase.');
+    return;
+  }
+
+  const keyboard = buildStyleKeyboard(styles);
+  await telegram.sendMessage(chatId, 'Choose the style you want:', {
+    reply_markup: {
+      inline_keyboard: keyboard,
+    },
+  });
+}
+
+function buildStyleKeyboard(styles) {
+  const keyboard = [];
+  for (let i = 0; i < styles.length; i += 2) {
+    const row = styles.slice(i, i + 2).map((style) => ({
+      text: style.title,
+      callback_data: `style:${style.id}`,
+    }));
+    keyboard.push(row);
+  }
+  return keyboard;
+}
+
+async function fetchActiveStyles() {
+  const { data, error } = await supabase
+    .from('styles')
+    .select('id, title, description')
+    .eq('is_active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Failed to fetch styles:', error);
+    return [];
+  }
+
+  return data ?? [];
+}
+
+async function handleCallbackQuery(callbackQuery) {
+  const chatId = callbackQuery.message?.chat?.id;
+  if (!chatId) {
+    await telegram.answerCallbackQuery(callbackQuery.id);
+    return;
+  }
+
+  const data = callbackQuery.data || '';
+  if (data.startsWith('style:')) {
+    const styleId = data.split(':')[1];
+    await telegram.answerCallbackQuery(callbackQuery.id, { text: 'Generating invoice…', show_alert: false });
+    await handleStyleSelection(styleId, callbackQuery.from, chatId);
+    return;
+  }
+
+  await telegram.answerCallbackQuery(callbackQuery.id);
+}
+
+async function handleStyleSelection(styleId, from, chatId) {
+  const { data: style, error: styleError } = await supabase
+    .from('styles')
+    .select('id, title, description')
+    .eq('id', styleId)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (styleError || !style) {
+    await telegram.sendMessage(chatId, 'That style is no longer available.');
+    return;
+  }
+
+  const latestUpload = await fetchLatestUpload(from.id);
+  if (!latestUpload) {
+    await telegram.sendMessage(chatId, 'I need a photo first. Please send one before choosing a style.');
+    return;
+  }
+
+  const { data: order, error: orderError } = await supabase
+    .from('orders')
+    .insert({
+      tg_user_id: from.id,
+      style_id: style.id,
+      price_stars: config.priceStars,
+      status: 'pending',
+    })
+    .select()
+    .single();
+
+  if (orderError) {
+    console.error('Failed to create order:', orderError);
+    await telegram.sendMessage(chatId, 'Could not create an order. Please try again later.');
+    return;
+  }
+
+  const invoicePayload = {
+    order_id: order.id,
+    style_id: style.id,
+    price_stars: config.priceStars,
+  };
+
+  try {
+    const invoiceLink = await telegram.createInvoiceLink({
+      title: `${style.title} Sticker Pack`,
+      description: style.description ?? 'Custom AI-generated sticker pack',
+      payload: JSON.stringify(invoicePayload),
+      currency: 'XTR',
+      prices: [
+        {
+          label: 'Sticker Pack',
+          amount: config.priceStars * 100,
+        },
+      ],
+    });
+
+    const { error: updateError } = await supabase
+      .from('orders')
+      .update({
+        invoice_link: invoiceLink,
+        invoice_payload: invoicePayload,
+      })
+      .eq('id', order.id);
+
+    if (updateError) {
+      throw updateError;
+    }
+
+    await telegram.sendMessage(chatId, `Pay ${config.priceStars} Stars to start the generation:`, {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            {
+              text: `Pay ${config.priceStars} ⭐`,
+              url: invoiceLink,
+            },
+          ],
+        ],
+      },
+    });
+  } catch (error) {
+    console.error('Failed to create invoice link:', error);
+    await telegram.sendMessage(chatId, 'Could not generate the payment link. Please try again in a moment.');
+  }
+}
+
+async function fetchLatestUpload(tgUserId) {
+  const { data, error } = await supabase
+    .from('uploads')
+    .select('id, storage_path, mime_type, created_at')
+    .eq('tg_user_id', tgUserId)
+    .eq('status', 'ready')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Failed to fetch latest upload:', error);
+    return null;
+  }
+
+  return data ?? null;
+}
+
+async function handleSuccessfulPayment(message) {
+  const chatId = message.chat.id;
+  const successfulPayment = message.successful_payment;
+  const tgUserId = message.from.id;
+
+  let invoicePayload = null;
+  try {
+    invoicePayload = JSON.parse(successfulPayment.invoice_payload);
+  } catch (error) {
+    invoicePayload = { order_id: successfulPayment.invoice_payload };
+  }
+
+  const orderId = invoicePayload.order_id;
+  if (!orderId) {
+    await telegram.sendMessage(chatId, 'Payment received, but the order could not be identified. A human will review it.');
+    return;
+  }
+
+  const { data: order, error: orderError } = await supabase
+    .from('orders')
+    .select('id, status, style_id')
+    .eq('id', orderId)
+    .maybeSingle();
+
+  if (orderError || !order) {
+    console.error('Order not found for payment:', orderError);
+    await telegram.sendMessage(chatId, 'Payment received, but there is no matching order. A human will assist you shortly.');
+    return;
+  }
+
+  if (order.status !== 'paid') {
+    const { error: updateError } = await supabase
+      .from('orders')
+      .update({ status: 'paid', paid_at: new Date().toISOString() })
+      .eq('id', order.id);
+    if (updateError) {
+      console.error('Failed to update order status to paid:', updateError);
+    }
+  }
+
+  await ensurePaymentRecorded(order.id, successfulPayment);
+  await ensureGenerationQueued(order.id, tgUserId, order.style_id);
+
+  await telegram.sendMessage(chatId, 'Payment confirmed! I am generating your sticker pack now. I will notify you when it is ready.');
+}
+
+async function ensurePaymentRecorded(orderId, successfulPayment) {
+  const chargeId = successfulPayment.telegram_payment_charge_id;
+
+  const { data: existingPayment, error: lookupError } = await supabase
+    .from('payments')
+    .select('id')
+    .eq('tg_charge_id', chargeId)
+    .maybeSingle();
+
+  if (lookupError) {
+    console.error('Failed to check existing payment:', lookupError);
+  }
+
+  if (existingPayment) {
+    return;
+  }
+
+  const amountStars = Math.round(successfulPayment.total_amount / 100);
+  const { error } = await supabase.from('payments').insert({
+    order_id: orderId,
+    tg_charge_id: chargeId,
+    amount_stars: amountStars,
+    status: 'succeeded',
+    provider_data: successfulPayment,
+  });
+
+  if (error) {
+    console.error('Failed to record payment:', error);
+  }
+}
+
+async function ensureGenerationQueued(orderId, tgUserId, styleId) {
+  const { data: existing, error: existingError } = await supabase
+    .from('generations')
+    .select('id')
+    .eq('order_id', orderId)
+    .maybeSingle();
+
+  if (existingError) {
+    console.error('Failed to check existing generation:', existingError);
+  }
+
+  if (existing) {
+    return;
+  }
+
+  const latestUpload = await fetchLatestUpload(tgUserId);
+  if (!latestUpload) {
+    console.warn('No upload found for generation, skipping queue.');
+    return;
+  }
+
+  const { error } = await supabase.from('generations').insert({
+    order_id: orderId,
+    input_upload_id: latestUpload.id,
+    engine: config.generationEngine,
+    prompt: `Sticker pack generation for style ${styleId}`,
+    params: { style_id: styleId },
+    status: 'queued',
+  });
+
+  if (error) {
+    console.error('Failed to enqueue generation:', error);
+  }
+}
+
+async function handleEraseCommand(tgUserId, chatId) {
+  const timestamp = new Date().toISOString();
+  try {
+    const { data: uploads, error: uploadsError } = await supabase
+      .from('uploads')
+      .select('id, storage_path')
+      .eq('tg_user_id', tgUserId);
+
+    if (uploadsError) throw uploadsError;
+
+    const uploadPaths = (uploads ?? [])
+      .map((item) => item.storage_path?.replace('storage://uploads/', ''))
+      .filter(Boolean);
+
+    if (uploadPaths.length) {
+      const { error: removeError } = await supabase.storage.from('uploads').remove(uploadPaths);
+      if (removeError) throw removeError;
+    }
+
+    const { error: updateUploadsError } = await supabase
+      .from('uploads')
+      .update({ status: 'deleted', deleted_at: timestamp })
+      .eq('tg_user_id', tgUserId);
+    if (updateUploadsError) throw updateUploadsError;
+
+    const { data: orders, error: ordersError } = await supabase
+      .from('orders')
+      .select('id')
+      .eq('tg_user_id', tgUserId);
+    if (ordersError) throw ordersError;
+
+    const orderIds = (orders ?? []).map((order) => order.id);
+    let generationIds = [];
+
+    if (orderIds.length) {
+      const { data: generations, error: generationsError } = await supabase
+        .from('generations')
+        .select('id')
+        .in('order_id', orderIds);
+      if (generationsError) throw generationsError;
+      generationIds = (generations ?? []).map((gen) => gen.id);
+    }
+
+    if (generationIds.length) {
+      const { data: stickers, error: stickersError } = await supabase
+        .from('stickers')
+        .select('id, storage_path')
+        .in('generation_id', generationIds);
+      if (stickersError) throw stickersError;
+
+      const stickerPaths = (stickers ?? [])
+        .map((item) => item.storage_path?.replace('storage://stickers/', ''))
+        .filter(Boolean);
+
+      if (stickerPaths.length) {
+        const { error: removeStickersError } = await supabase.storage.from('stickers').remove(stickerPaths);
+        if (removeStickersError) throw removeStickersError;
+      }
+
+      const { error: deleteGenerations } = await supabase
+        .from('generations')
+        .delete()
+        .in('id', generationIds);
+      if (deleteGenerations) throw deleteGenerations;
+    }
+
+    const { error: logError } = await supabase.from('webhook_events').insert({
+      source: 'telegram',
+      event_type: 'command:/erase',
+      payload: { tg_user_id: tgUserId },
+      tg_user_id: tgUserId,
+    });
+    if (logError) {
+      console.error('Failed to log erase command:', logError);
+    }
+
+    await telegram.sendMessage(chatId, 'Your uploads and generated stickers have been deleted. We may keep payment records for legal reasons.');
+  } catch (error) {
+    console.error('Failed to handle /erase command:', error);
+    await telegram.sendMessage(chatId, 'There was a problem deleting your data. A human will review this request.');
+  }
+}
+
+async function upsertTelegramProfile(from) {
+  const profile = {
+    tg_user_id: from.id,
+    tg_username: from.username ?? null,
+    first_name: from.first_name ?? null,
+    language_code: from.language_code ?? null,
+    is_premium: from.is_premium ?? false,
+    last_seen_at: new Date().toISOString(),
+  };
+
+  const { error } = await supabase.from('telegram_profiles').upsert(profile, {
+    onConflict: 'tg_user_id',
+  });
+
+  if (error) {
+    console.error('Failed to upsert telegram profile:', error);
+  }
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,10 @@
+const { createClient } = require('@supabase/supabase-js');
+const config = require('../config');
+
+const supabase = createClient(config.supabaseUrl, config.supabaseServiceRoleKey, {
+  auth: {
+    persistSession: false,
+  },
+});
+
+module.exports = supabase;

--- a/src/lib/telegram.js
+++ b/src/lib/telegram.js
@@ -1,0 +1,68 @@
+const axios = require('axios');
+const config = require('../config');
+
+const apiBase = `https://api.telegram.org/bot${config.telegramBotToken}`;
+const fileBase = `https://api.telegram.org/file/bot${config.telegramBotToken}`;
+
+async function callTelegram(method, payload = {}) {
+  try {
+    const response = await axios.post(`${apiBase}/${method}`, payload, {
+      timeout: 10000,
+    });
+    if (!response.data.ok) {
+      throw new Error(`Telegram API error: ${response.data.description}`);
+    }
+    return response.data.result;
+  } catch (error) {
+    if (error.response?.data) {
+      console.error('Telegram API response error:', error.response.data);
+    }
+    throw error;
+  }
+}
+
+async function sendMessage(chatId, text, extra = {}) {
+  return callTelegram('sendMessage', {
+    chat_id: chatId,
+    text,
+    ...extra,
+  });
+}
+
+async function answerCallbackQuery(id, options = {}) {
+  return callTelegram('answerCallbackQuery', {
+    callback_query_id: id,
+    ...options,
+  });
+}
+
+async function answerPreCheckoutQuery(id, ok = true, errorMessage) {
+  return callTelegram('answerPreCheckoutQuery', {
+    pre_checkout_query_id: id,
+    ok,
+    error_message: ok ? undefined : errorMessage,
+  });
+}
+
+async function createInvoiceLink(payload) {
+  return callTelegram('createInvoiceLink', payload);
+}
+
+async function getFile(fileId) {
+  return callTelegram('getFile', { file_id: fileId });
+}
+
+async function downloadFile(filePath) {
+  const url = `${fileBase}/${filePath}`;
+  const response = await axios.get(url, { responseType: 'arraybuffer', timeout: 10000 });
+  return Buffer.from(response.data);
+}
+
+module.exports = {
+  answerCallbackQuery,
+  answerPreCheckoutQuery,
+  createInvoiceLink,
+  downloadFile,
+  getFile,
+  sendMessage,
+};


### PR DESCRIPTION
## Summary
- add a configurable Express webhook server that stores uploads, creates orders, records payments, and queues generations in Supabase
- include Telegram API and Supabase helper modules plus environment template for local setup
- expand README and getting started guide with Node.js workflow and ngrok webhook instructions
- extend Supabase SQL with a unique index for `tg_charge_id` to avoid duplicate payment rows

## Testing
- TELEGRAM_BOT_TOKEN=123:abc SUPABASE_URL=https://example.supabase.co SUPABASE_SERVICE_ROLE_KEY=examplekey TELEGRAM_WEBHOOK_SECRET=test PORT=9999 node src/index.js


------
https://chatgpt.com/codex/tasks/task_e_68cc3e264d38832d95347a2e8eb859f9